### PR TITLE
33 add related posts on posts pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'jekyll-feed'
 gem 'jekyll-compose', group: [:jekyll_plugins]
 gem 'jekyll-sitemap'
 gem 'jekyll-seo-tag'
+gem "jekyll-tagging-related_posts"

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-seo-tag
+  - jekyll-tagging-related_posts
 
 #plugins:
 #- jekyll-remote-theme # add this line to the plugins list if you already have one

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -22,3 +22,15 @@ layout: default
 
 
 {{ content }}
+
+{% if site.related_posts.size >= 1 %}
+<div>
+  <h3>Artículos relacionados</h3>
+  <hr>
+  <ul>
+  {% for related_post in site.related_posts limit: 5 %}
+    <li><a href="{{ related_post.url }}">{{ related_post.title }}</a></li>
+  {% endfor %}
+  </ul>
+</div>
+{% endif %}


### PR DESCRIPTION
Applied jekyll-tagging-related_posts plugin: https://github.com/toshimaru/jekyll-tagging-related_posts