### PR TITLE
27 set blog by curso layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 assets/img/blog/.jekyll-cache
 Gemfile.lock
 .vscode/settings.json
-_drafts

--- a/_drafts/conceptos-básicos-sobre-comunicaciones-en-kubernetes.md
+++ b/_drafts/conceptos-básicos-sobre-comunicaciones-en-kubernetes.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: Conceptos básicos sobre comunicaciones en Kubernetes
+description: Conceptos fundamentales para comprender las comunicaciones dentro de
+  un cluster de Kubernetes.
+image: kubernetes-for-beginners
+category: devops
+tags:
+- devops
+- apuntes
+- kubernetes
+curso: kubernetes-for-beginners
+author: Antonio
+---
+- Table of concepts
+{:toc}
+
+Todos los contenerdores/PODs tienen visibilidad a nivel interno de comunicaciones IP entre todos ellos, por defecto. Otro tema es la comunicación con el exterior del cluster. ¿Cómo exponemos nuestras aplicaciones? ¿Qué conceptos básicos debemos dominar par llegar a dominar el networking de Kubernetes?
+
+
+## Services
+
+## NodePort
+
+## ClusterIP
+
+## LoadBalancer

--- a/_layouts/blog_by_curso.html
+++ b/_layouts/blog_by_curso.html
@@ -1,35 +1,26 @@
 ---
 layout: default
 ---
+<hr>
 
-<div class="container">
-  {% if site.categories[page.slug] %}
-  	<!-- bucle principal -->
-    {% for post in site.categories[page.slug] %}
-      {% capture post_year %}{{ post.date | date: '%Y' }}{% endcapture %}
-      {% if forloop.first %}
-        <h3 class="year">{{ post_year }}</h3>
-        <div class="list-group">
-      {% endif %}
-      {% unless forloop.first %}
-        {% assign previous_index = forloop.index0 | minus: 1 %}
-        {% capture previous_post_year %}{{ site.categories[page.slug][previous_index].date | date: '%Y' }}{% endcapture %}
-        {% if post_year != previous_post_year %}
-        </div>
-        <h3 class="year">{{ post_year }}</h3>
-        <div class="list-group">
-        {% endif %}
-      {% endunless %}
-        <a href="{{ site.baseurl }}{{ post.url }}" class="list-group-item">
-          <h4 class="list-group-item-heading">{{ post.date | date: "%-d/%-m" }} - {{ post.title }}</h4>
-
-        </a>
-      {% if forloop.last %}
-        </div>
-      {% endif %}
-    {% endfor %}
-    <!-- fin bucle principal -->
-  {% else %}
-    <p>No existen posts para esta curso.</p>
+  {% for curso in site.cursos %}
+  {% if curso.slug == page.slug %}
+ 
+      {% for post in site.posts %}
+      {%if page.slug == post.curso %}
+      <ul>
+        <li>
+        <h3><a href="{{ post.url }}">{{ post.title }}</a>  </h3>
+        <p>Etiquetas: / {% for tag in post.tags %}<a href="/blog/tags/{{ tag }}"> {{ tag }} </a>/{% endfor %}</p>
+        <hr>
+        </li>
+      </ul>
   {% endif %}
-</div>
+  {% endfor %}
+    </li>
+
+  {% endif %}
+
+  {% endfor %}
+
+

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,9 +1,19 @@
 ---
 layout: default
 ---
+
+
 {% for var in site.featured_categories %}
     {% if var.slug == page.category %}
     {% capture category_link %}
+    <a class="label" href="{{ site.baseurl }}{{ var.url }}">{{ var.name }}</a>
+    {% endcapture %} 
+	{% endif %}
+{% endfor %}
+
+{% for var in site.cursos %}
+    {% if var.slug == page.curso %}
+    {% capture curso_link %}
     <a class="label" href="{{ site.baseurl }}{{ var.url }}">{{ var.name }}</a>
     {% endcapture %} 
 	{% endif %}
@@ -13,6 +23,8 @@ layout: default
 
 
 <p>Fecha: {{ page.date | date_to_string }} - Autor: <a href="/about">{{ page.author }}</a></p>
+<hr>
+<p>{% if curso_link %}Formación: {{ curso_link }}{% endif %}</p>
 <p class="post-cat">
   {% if category_link %}Post en Categoría: {{ category_link }}{% endif %}
 </p>


### PR DESCRIPTION
- First version of _layouts/blog_by_curso.html: need to improve when to show a message if there are no published pods for the given course.
- Adaptation in _layouts/post.html to validate if the current post has `curso` field in the front matter. If valid, print a line with a link to the course page.
- Create first post draft related to a specific course: _drafts/conceptos-básicos-sobre-comunicaciones-en-kubernetes.md, only for testing porpouse.