### PR TITLE
74 jekyll gist liquid tag for displaying GitHub gists in jekyll sites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem 'jekyll-sitemap'
 gem 'jekyll-seo-tag'
 gem "jekyll-tagging-related_posts"
 gem "jekyll-readme-index"
+gem 'jekyll-gist'

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ plugins:
   - jekyll-seo-tag
   - jekyll-tagging-related_posts
   - jekyll-readme-index
+  - jekyll-gist
 
 #plugins:
 #- jekyll-remote-theme # add this line to the plugins list if you already have one
@@ -127,3 +128,6 @@ feed:
   path: /blog/feed.xslt.xml
   excerpt_only: false
 
+# jekyll-gist configuration
+gist:
+  noscript: false

--- a/_posts/2023-07-10-Crea-tu-primer-post-en-Jekyll.md
+++ b/_posts/2023-07-10-Crea-tu-primer-post-en-Jekyll.md
@@ -6,17 +6,30 @@ description: Guía para crear tu primera publicación en tu blog de Jekyll. Paso
 category: blogging
 tags: [tutoriales, jekyll]
 ---
-- Tabla de contenidos
-{:toc}
+1. Tabla de contenidos
+{:toc large-only}
+
+- [1. Crear carpeta "\_posts"](#1-crear-carpeta-_posts)
+  - [1.1. Crear nuestro primer artículo](#11-crear-nuestro-primer-artículo)
+- [2. Listado de posts](#2-listado-de-posts)
+- [3. Crear categorías o tags.](#3-crear-categorías-o-tags)
+  - [3.1. Configuración](#31-configuración)
+  - [3.2. Añadir elementos a cada colección](#32-añadir-elementos-a-cada-colección)
+  - [3.3. Página de etiquetas](#33-página-de-etiquetas)
+  - [3.4. Posts por etiqueta o categoría](#34-posts-por-etiqueta-o-categoría)
+- [4. Recursos](#4-recursos)
+
+
+
 
 En este artículo recogemos todos los pasos necesarios para crear nuestra primera publicación en un blog que está en Jekyll.
 {:.lead}
 
-## Crear carpeta "_posts"
+## 1. Crear carpeta "_posts"
 
 En el raiz de nuestro proyecto crearemos la carpeta `_posts`, que es donde se almacenarán todos los artículos que vayamos creando en el post.
 
-### Crear nuestro primer artículo
+### 1.1. Crear nuestro primer artículo
 
 Dentro de la carpeta `_posts` crearemos un fichero con el siguiente formato:
 
@@ -30,10 +43,11 @@ Para que veamos el ejemplo de este mismo artículo, sería algo así:
 2023-07-10-Crear-tu-primer-post-en-Jekyll.md
 ```
 
-## Listado de posts
+## 2. Listado de posts
 
 Por defecto, este tema muestra los posts en la carpeta `/blog`, siempre y cuando tengamos dentro un fichero index.html con el siguiente código en el Front Matter
 ```yaml
+# file: "blog.html"
 ---
 layout: default
 title: Blog
@@ -43,18 +57,18 @@ description: >
 
 ```
 
-## Crear categorías o tags. 
+## 3. Crear categorías o tags. 
 
 Según la documentación de Jekyll podemos organizar la información a través de colecciones. 
 
-### Configuración
+### 3.1. Configuración
 
 Primero de todo debemos indicarle a Jekyll de la existencia de nuestra nueva colección. Esto se hace en el fichero `_config.yaml`.
 
 Dado que lo que queremos es crear dos tipos de agrupaciones: categorías y etiquetas, añadiremos el siguiente texto al fichero yaml.
 
 ~~~yaml
-file: '_config.yml'
+file: "_config.yml"
 ---
 collections:
   featured_categories:
@@ -65,7 +79,7 @@ collections:
     output:            true
 ~~~
 
-### Añadir elementos a cada colección
+### 3.2. Añadir elementos a cada colección
 
 Tenemos dos colecciones: `featured_categories` y `featured_tags`, como se observa en el bloque anterior. Debemos crear una carpeta por cada una de dichas colecciones en el directorio raíz de nuestro proyecto Jekyll y dentro crearemos un fichero markdown por cada una de las categorías y etiquetas que queramos incluir en nuestro blog.
 
@@ -76,6 +90,7 @@ En la imagen se ve el ejemplo de las dos primeras categorías y etiquetas de est
 Dentro de cada fichero podemos crear un Front Matter como el que ponemos a continuación de ejemplo:
 
 ~~~yaml
+# file: "jekyll.md"
 ---
 name:  Jekyll
 slug:   jekyll
@@ -87,6 +102,7 @@ description: >
 Podemos observar que no hemos definido ningún `layout`. Esto es por que lo hemos definido a nivel global dentro del fichero `_config.yml` bajo la sección `defaults`.
 
 ~~~yaml
+# file: "_config.yaml"
 defaults:
   -
     scope:
@@ -118,30 +134,16 @@ Como podemos ver en los dós últimos bloques de `scope`, estamos referenciando 
 
 De este modo, en cuando se renderize nuestro sitio, se creará una página automática para cada etiqueta o categoría. En los layouts o plantillas de  `blog_by_tag` y `blog_by_category` explicaremos más adelante el código utilizado para que nos muestre las entradas del blog relacionadas con cada etiqueta o categoría. 
 
-### Página de etiquetas
+### 3.3. Página de etiquetas
 
 También tenemos que una página de etiquteas en la raíz de nuestro proyecto o en la carpeta blog, donde ya habíamos creado el index.html del blog (no confundir con el index.html de la raíz del proyecto donde está la Home de la web).
 
 Introduciremos el siguiente código en nuestro fichero `tags.html`
 
- {% raw %}
-```html
-===
-layout: page
-title: Etiquetas
----
-{% for tag in site.tags %}
- <h4><a href="/blog/tags/{{ tag[0] }}"> {{ tag[0] }} </a></h4>
-  <ul>
-    {% for post in tag[1] %}
-      <li><a  href="{{ post.url }}">{{ post.title }}</a></li>
-    {% endfor %}
-  </ul>
-{% endfor %}
+{% gist 68b9722b4b084148e92d6f07fa6136ab tags.html %}
 
-<hr>
-```
- {% endraw %}
+Código para crear un índice de etiquetas con sus correspondientes posts relacionados en la ruta `/blog/tags.html`
+{:.figcaption}
 
 Lo que estamos haciendo es iterar todos los ficheros que tenemos en la carpeta `_featured_tags`, en el momento de escribir este post son: `Apuntes.md, Blogging.md, y Tutoriales.md`, para crear un título `h4` por cada etiqueta, y para obtener cada post volvemos recorrer cada post con la etiqueta correspondiente y creamos un enlace a dicho post. 
 
@@ -150,7 +152,7 @@ El resultado es el siguiente:
 
 <img src="/assets/img/blog/tags-page-detail.png" title="" alt="Tag page detail" width="300" height="200" style="border: 1px solid #000;float: center;">
 
-### Posts por etiqueta o categoría
+### 3.4. Posts por etiqueta o categoría
 
 Ya sólo nos falta crear las plantillas que nos mostrarán las entradas relacionadas con cada etiqueta o categoría. En este ejemplo sólo vamos a hablar del caso de las etiquetas, pero el de las categorías es exactamente igual sólo hay que cambiar cualquier referencia a `tags` por `categories`.
 
@@ -158,46 +160,12 @@ La guía fundamental que he utilizado el [blog de dsigno](https://dsigno.github.
 
 Este sería el código:
 
-{% raw %}
-```html
----
-layout: default
----
+{% gist 68b9722b4b084148e92d6f07fa6136ab blog_by_tag.html %}
 
-<div class="container">
-  {% if site.tags[page.slug] %}
-  	<!-- bucle principal -->
-    {% for post in site.tags[page.slug] %}
-      {% capture post_year %}{{ post.date | date: '%Y' }}{% endcapture %}
-      {% if forloop.first %}
-        <h3 class="year">{{ post_year }}</h3>
-        <div class="list-group">
-      {% endif %}
-      {% unless forloop.first %}
-        {% assign previous_index = forloop.index0 | minus: 1 %}
-        {% capture previous_post_year %}{{ site.tags[page.slug][previous_index].date | date: '%Y' }}{% endcapture %}
-        {% if post_year != previous_post_year %}
-        </div>
-        <h3 class="year">{{ post_year }}</h3>
-        <div class="list-group">
-        {% endif %}
-      {% endunless %}
-        <a href="{{ site.baseurl }}{{ post.url }}" class="list-group-item">
-          <h4 class="list-group-item-heading">{{ post.title }}</h4>
-          <p class="list-group-item-date">{{ post.date | date: "%-d/%-m/%Y" }}</p>
-        </a>
-      {% if forloop.last %}
-        </div>
-      {% endif %}
-    {% endfor %}
-    <!-- fin bucle principal -->
-  {% else %}
-    <p>No existen posts para este TAG.</p>
-  {% endif %}
-</div>
-```
- {% endraw %}
-## Recursos
+Código para crear un índice de posts por etiqueta en la ruta `/layouts/blog_by_tag.html`
+{:.figcaption}
+
+## 4. Recursos
 
 Documentación oficial de [Jekyll](https://jekyllrb.com/docs/step-by-step/08-blogging/){:target="_blank"}
 

--- a/_posts/2023-07-17-jekyll-compose-automatiza-el-manejo-de-ficheros-en-jekyll.md
+++ b/_posts/2023-07-17-jekyll-compose-automatiza-el-manejo-de-ficheros-en-jekyll.md
@@ -37,9 +37,10 @@ Tenemos que hacer dos cosas: abrir automáticamente los nuevos borradores o post
 
 ### Abrir automáticamente los ficheros
 
-Tenemos  que añadir estas líneas en nuestro `_config.yaml`
+Tenemos  que añadir estas líneas en nuestro fichero de configuración de Jekyll.
 
 ~~~yaml
+# file: "_config.yml"
   jekyll_compose:
     auto_open: true
 ~~~
@@ -55,6 +56,7 @@ $ export JEKYLL_EDITOR=vscode
 Añadiremos los siguiente en el `_config.yaml`
 
 ~~~yaml
+# file: "_config.yaml"
 jekyll_compose:
   default_front_matter:
     drafts:

--- a/_posts/2023-07-17-jekyll-feed-plugin-para-crear-un-fichero-de-feeds.md
+++ b/_posts/2023-07-17-jekyll-feed-plugin-para-crear-un-fichero-de-feeds.md
@@ -20,13 +20,15 @@ jekyll-feed es un plugin que automatiza la generación de un fichero de feed en 
 
 Como en ejemplos anteriores de otros plugins, añadimos la gema a nuestro fichero `Gemfile` y ejecutamos el comando `bundle`
 
-~~~Gemfile
+~~~ruby
+# file: "Gemfile"
 gem 'jekyll-feed'
 ~~~
 
 Posteriormente añadimos a nuestro fichero de configuración `_config.yaml` la correspondiente línea refiriendose al plugin:
 
 ~~~yaml
+# file: "_config.yml"
 plugins:
   - jekyll-feed
 ~~~
@@ -38,6 +40,7 @@ Simplemente con estos dos pasos ya se genera automáticamente un fichero `/feed.
 Adjuntamos a continuación las líneas referentes a la configuración del plugin en el fichero `_config.yaml`.
 
 ~~~yaml
+# file: "_config.yml"
 # Jekyll-feed configuration
 
 feed:

--- a/_posts/2023-07-17-jekyll-sitemap-crea-el-sitemap-de-tu-web-en-jekyll.md
+++ b/_posts/2023-07-17-jekyll-sitemap-crea-el-sitemap-de-tu-web-en-jekyll.md
@@ -18,9 +18,10 @@ jekyll-sitemap es un plugin que genera un fichero `sitemap.xml` a partir de los 
 
 ## Instalación
 
-1. Como de costumbre, añadimos la línea referenciando a la gema correspondiente en nuestro `Gemfile` y posteriormente ejecutamos el comando `bundle`
+Como de costumbre, añadimos la línea referenciando a la gema correspondiente en nuestro `Gemfile` y posteriormente ejecutamos el comando `bundle`
 
-~~~Gemfile
+~~~ruby
+# file: "Gemfile"
 gem 'jekyll-sitemap'
 ~~~
 
@@ -36,7 +37,13 @@ $ bundle info jekyll-sitemap
                 github-pages (228) depends on jekyll-sitemap (= 1.4.0)
 ~~~
 
-2. Añadimos el plugin en la colección de plugins de nuestro fichero de configuración `_config.yaml`
+Por último el plugin en la colección de plugins de nuestro fichero de configuración `_config.yaml`
+
+```yaml
+# file: "_config.yml"
+plugins:
+  - jekyll-sitemap
+```
 
 ## Exclusiones
 
@@ -45,6 +52,7 @@ Podemos decidir qué partes de nuestro sitio web son excluidas del fichero `site
 Para que lo veamos con un ejemplo lo haremos en este blog con la sección `featured_tags`, dejando así excluidas todas las etiquetas de nuestro blog:
 
 ~~~yaml
+# file: "_config.yaml"
 defaults:
   -
     scope:

--- a/_posts/2023-07-23-creando-tus-propias-colleciones-en-jekyll.md
+++ b/_posts/2023-07-23-creando-tus-propias-colleciones-en-jekyll.md
@@ -60,25 +60,14 @@ En el [primer post](http://antoniomuniz.com/blogging/2023/07/10/Crea-tu-primer-p
 
 Por tanto, primer paso. Declarar en el fichero de configuración de nuestro proyecto Jekyll que vamos a tener una nueva colección llamada `cursos`. Vamos al fichero `_config.yml` del proyecto y donde ya teníamos creadas las colecciones `featured_tags` y `featured_categories` añadimos la nueva:
 
-```yaml
-# file: "_config.yaml"
-
-collections:
-  featured_categories:
-    permalink:         /blog/categories/:name/
-    output:            true
-  featured_tags:
-    permalink:         /blog/tags/:name/
-    output:            true
-  cursos:
-    permalink: /blog/:collection/:name
-    output: true
-```
+{% gist c1d589fb2125f6e0b07097aff79bb092 _config.yml %}
 
 Detalle sobre cómo queda nuestro fichero de configuración
 {:.figcaption}
 
 Importante definir el campo `permalink` que será la base sobre la que se montará la url de cada página de cada curso de la colección y también el campo `output` que permite a Jekyll identificar que esta colección generará una página por cada elemento de la colección existente. 
+
+El campo `sort_by`, que vemos en la línea 11, será explicado más adelante cuando entremos en los detalles de la ["ordenación por claves del front matter"](#61-ordenación-por-claves-del-front-matter)
 
 En la [documentación oficial de Jekyll](https://jekyllrb.com/docs/collections/#setup){:target="_blank"} se dan más detalles respecto al setup.
 {:.note title="Más sobre colecciones"}
@@ -110,6 +99,9 @@ description: >
 ---
 ```
 
+Ejemplo del front matter de uno de los cursos
+{:.figcaption}
+
 Es importante la elección de los campos que definimos en el `Front Matter` puesto que luego los tendremos que referenciar para la programación que haremos en el layout llamado `blog_boy_curso.html`. Nosotros hemos elegido los siguientes campos por los siguientes motivos:
 
 - **name**: El nombre que se utilizará como título cuando referenciemos la variable `curso.name`.
@@ -130,34 +122,16 @@ http://antoniomuniz.com/blog/cursos/vim-profesional
 
 Procedemos pues a crear un índice para estas páginas. En nuestra carpeta `/blog` del proyecto crearemos el fichero `cursos.html`. En la versión actual hemos escrito el siguiente código:
 
-{% raw %}
-```html
-<!-- file: "/blog/cursos.html" -->
----
-layout: page
-title: Apuntes
-name: cursos
-slug: cursos
-description: >
-  Relación de apuntes tomados en cursos que voy haciendo, sobre conceptos clave que necesito entender mejor.
----
-<ul>
-    {% for curso in site.cursos %}
-      <li>
-        <h2><a href="/blog/cursos/{{ curso.slug }}">{{ curso.name }}</a></h2>
-        <p><q>{{ curso.description }}</q> ->  <a href="{{ curso.link }}" Target="_blank">Enlace al curso</a></p>
-        <hr>
-      </li>
-    {% endfor %}
-  </ul>
-```
-{% endraw %}
+{% gist c1d589fb2125f6e0b07097aff79bb092 cursos.html %}
+
+Detalle sobre código html para la página donde mostraremos el índice de los cursos "/blog/cursos.html"
+{:.figcaption}
 
 Empezamos a ver aquí el potencial de Jekyll + Liquid. Estamos iterando la variable de Jekyll `site.cursos` de modo que recorremos los cuatro ficheros que definiamos antes con los nombres de cada curso y creamos un título `h2` por cada uno para ello usamos las variables `curso.slug` en el link y `curso.name` en el texto del enlace.
 
 Para completar éste índice añadimos un párrafo en el que añadimos un cita -etiqueta <q> en html- con la descripción del curso, `curso.description` y por último un enlace en una nueva pestaña -`target="_blank"` dentro de la etiqueta <a>- invocando a la variable `curso.link`
 
-Por tanto hacemos uso de todos los campos del `Front Matter` de cada fichero que habíamos definido en el [punto anterior](#2-añadir-contenido).
+Por tanto hacemos uso de todos los campos del `Front Matter` de cada fichero que habíamos definido en el [punto anterior](#3-añadir-contenido).
 
 ## 5. Permalinks
 
@@ -182,17 +156,7 @@ Explicaremos ambas a continuación.
 
 Aprovechando las capacidades que nos brinda Jekyll, podemos definir un campo ad hoc para la ordenación de nuestros artículos. En nuestro caso al tratarse de tutoriales/apuntes vinculados a cursos, podemos definir que cada artículo sea una lección. De modo que en el fichero `_config.yaml` además de las entradas para permalinks y output, añadiremos ahora el campo `sort_by` cuyo valor será `lesson`. Cuando definamos el front matter de los posts que queramos añadir al curso, añadiremos el campo `lesson` y le asignaremos el número entero que corresponda al orden que queremos darle.
 
-Por tanto son necesarias dos operaciones. Añadir el nuevo campo `sort_by` bajo la colección en el fichero de configuración y en cada nuevo post añadir campo `lesson` y darle el valor que corresponda.
-
-```yaml
-# file: "_config.yaml"
-
-collections:
-  cursos:
-    permalink: /blog/:collection/:name
-    output: true
-    sort_by: lesson
-```
+Por tanto son necesarias dos operaciones. Añadir el nuevo campo `sort_by` bajo la colección en el fichero de configuración y en cada nuevo post añadir campo `lesson` y darle el valor que corresponda. Como veíamos en el gist que veíamos en el [punto 2](#2-configuración) de ésta guía.
 
 Un ejemplo del front matter de nuestro primer artículo perteneciente a un curso sería este:
 
@@ -211,16 +175,10 @@ Si comenzamos a asignar un orden pero dejamos de hacerlo, lo que pasará es que 
 
 Otra opción es dar un orden manual desde el propio fichero de configuración, pero en lugar de `sort_by` utilizaremos la palabra clave `order`. Ponemos un ejemplo copiado de la documentación oficial, porque en este proyecto no hemos elegido esta opción manual pero la referenciamos igualmente para su mayor comprensión.
 
-```yaml
-# file: "example.yaml"
-collections:
-  tutorials:
-    order:
-      - hello-world.md
-      - introduction.md
-      - basic-concepts.md
-      - advanced-concepts.md
-```
+{% gist c1d589fb2125f6e0b07097aff79bb092 example.yml %}
+
+Ejemplo de la configuración que tendríamos que hacer en el fichero `_config.yml`si queremos ordenación manual.
+{:.figcaption}
 
 ## 7. Atributos Liquid
 
@@ -246,45 +204,10 @@ Pongamos en práctica todo lo aprendido hasta ahora.
 
 Añadimos a continuación el código de la primera versión funcional del archivo `/layouts/blog_by_curso.html`
 
-{% raw %}
-```html
-<!-- file: "/layouts/blog_by_curso.html" -->
----
-layout: default
----
-{% assign num_filtered_posts = site.posts | where: 'curso', page.slug | size  %}
-{% assign filtered_posts = site.posts | where: 'curso', page.slug   %}
+{% gist c1d589fb2125f6e0b07097aff79bb092 blog_by_curso.html %}
 
-{% for cursos in site.cursos %}
-  {% if cursos.slug == page.slug %}
-
-    {% assign curso_link = cursos.link %}
-  {% endif %}
-{% endfor %}
- 
-<p><a href="{{ curso_link }}" target="_blank">Enlace al curso</a></p>
-<hr>
-
-{% if num_filtered_posts > 0 %} 
-
-  {% for post in filtered_posts %} 
-    <ul>
-      <li>
-       <h3><a href="{{ post.url }}">{{ post.title }}</a>  </h3>
-       <p>Etiquetas: / {% for tag in post.tags %}<a href="/blog/tags/{{ tag }}"> {{ tag }} </a>/{% endfor %} - {{ post.date | date_to_string}}</p>
-       <hr>
-       </li>
-     </ul>
-  {% endfor %}
-
-{% else %}
-
-<p>Aún no existen artículos para este curso</p>
-
-{% endif %}
-
-```
-{% endraw %}
+Código creado para mostrar los posts relacionados con un curso concreto en la ruta `/layouts/blog_by_curso.html`
+{:.figcaption}
 
 ### 8.2. La explicación
 


### PR DESCRIPTION
Install jekyll-gist plugin succesfully
Post edition to enhance usability by linking code-blocks tu public gists.